### PR TITLE
Include freevrrpd patch from the port

### DIFF
--- a/vrrp_network.c
+++ b/vrrp_network.c
@@ -113,7 +113,7 @@ vrrp_network_init_iphdr(char *buffer, struct vrrp_vr * vr)
 	 iph->ip_hl = 5;
 	 iph->ip_v = 4;
 	 iph->ip_tos = 0;
-#if defined(__FreeBSD__) || defined(__NetBSD__)
+#if (defined(__FreeBSD__) && (__FreeBSD_version < 1100030)) || defined(__NetBSD__)
 	 iph->ip_len = sizeof(struct ip) + vrrp_network_vrrphdr_len(vr) + vrrp_ah_ahhdr_len(vr);
 #else
 	 iph->ip_len = htons(sizeof(struct ip) + vrrp_network_vrrphdr_len(vr) + vrrp_ah_ahhdr_len(vr));


### PR DESCRIPTION
Current port add a patch for freevrrpd: files/patch-vrrp_network.c
This is a change related to SOCK_RAW changes in FreeBSD-current explained here https://wiki.freebsd.org/SOCK_RAW